### PR TITLE
PhoneMask Module updated for international phone number

### DIFF
--- a/PhoneMask/src/index.js
+++ b/PhoneMask/src/index.js
@@ -16,24 +16,73 @@
  */
 
 // src/index.js
-
 function formatPhone(input) {
-  let value = input.value.replace(/[^\d-]/g, '');
+  // Get the raw value and remove any non-digit characters
+  let value = input.value.replace(/[^\d]/g, '');
   let formattedValue = value;
 
-  // i.e. 111-222-3333
-  const del = '-';
-  const pos = value.length;
-  if ([3, 7].includes(pos)) {
-    // handles user typing
-    formattedValue += del;
-    input.value = formattedValue;
-  } else if (pos >= 10 && formattedValue.indexOf(del) < 0) {
-    // full phone number pasted
-    formattedValue = value.substring(0, 3) + del + value.substring(3, 6) + del + value.substring(6, 10);
-    input.value = formattedValue;  
-  }
+
+  // I might be wrong about the international phone number style
+  // However, You can add and update the format as following
+  const formats = {
+    'US': {
+      pattern: /^(\d{3})(\d{3})(\d{4})$/,
+      format: '$1-$2-$3', // e.g., 111-222-3333
+      partial: (v) => {
+        if (v.length <= 3) return v;
+        if (v.length <= 6) return v.slice(0, 3) + '-' + v.slice(3);
+        return v.slice(0, 3) + '-' + v.slice(3, 6) + '-' + v.slice(6);
+      }
+    },
+    'UK': {
+      pattern: /^(\d{4})(\d{3})(\d{3})$/,
+      format: '$1 $2 $3', // e.g., 020 7123 4567
+      partial: (v) => {
+        if (v.length <= 4) return v;
+        if (v.length <= 7) return v.slice(0, 4) + ' ' + v.slice(4);
+        return v.slice(0, 4) + ' ' + v.slice(4, 7) + ' ' + v.slice(7);
+      }
+    },
+    'FR': {
+      pattern: /^(\d{1})(\d{2})(\d{2})(\d{2})(\d{2})$/,
+      format: '$1 $2 $3 $4 $5', // e.g., 1 23 45 67 89
+      partial: (v) => {
+        if (v.length <= 2) return v;
+        if (v.length <= 4) return v.slice(0, 2) + ' ' + v.slice(2);
+        if (v.length <= 6) return v.slice(0, 2) + ' ' + v.slice(2, 4) + ' ' + v.slice(4);
+        if (v.length <= 8) return v.slice(0, 2) + ' ' + v.slice(2, 4) + ' ' + v.slice(4, 6) + ' ' + v.slice(6);
+        return v.slice(0, 2) + ' ' + v.slice(2, 4) + ' ' + v.slice(4, 6) + ' ' + v.slice(6, 8) + ' ' + v.slice(8);
+      }
+    },
+    'KR': {
+      pattern: /^(\d{3})(\d{4})(\d{4})$/,
+      format: '$1-$2-$3', // e.g., 010-1234-5678
+      partial: (v) => {
+        if (v.length <= 4) return v;
+        if (v.length <= 7) return v.slice(0, 4) + '-' + v.slice(4);
+        return v.slice(0, 4) + '-' + v.slice(4, 7) + '-' + v.slice(7);
+      }
+    }
+  };
+
+  // Get the selected country code from the dropdown
+  const countrySelector = document.getElementById('country-code');
+  let country = countrySelector.value; // Get the selected country code
   
+
+  // Check if the country has a defined format
+  if (formats[country]) {
+    // As the user is still typing, apply partial formatting
+    formattedValue = formats[country].partial(value);
+
+    // If the number is complete and matches the country's pattern, format it fully
+    if (formats[country].pattern.test(value)) {
+      formattedValue = value.replace(formats[country].pattern, formats[country].format);
+    }
+  }
+
+  // Set the formatted value back to the input
+  input.value = formattedValue;
 }
 
 module.exports = {
@@ -41,6 +90,11 @@ module.exports = {
     const $ = require('jquery');
     $(selector).on('input', function() {
       formatPhone(this);
+    });
+
+    // Attach the country code change event
+    $('#country-code').on('change', function() {
+      formatPhone(document.getElementById('input'));
     });
   }
 };

--- a/PhoneMask/test/index.test.js
+++ b/PhoneMask/test/index.test.js
@@ -31,15 +31,31 @@ global.navigator = {
 };
 
 const input = window.document.createElement('input');
+
 input.type = 'tel';
 input.id = 'phone';
 window.document.body.appendChild(input);
 
+const countrySelector = window.document.createElement('select');
+    countrySelector.id = 'country-code';
+    countrySelector.innerHTML = `
+      <option value="US">US</option>
+      <option value="UK">UK</option>
+      <option value="FR">FR</option>
+      <option value="KR">KR</option>
+    `;
+    
+    window.document.body.appendChild(countrySelector);
+
 
 // Test cases
 describe('PhoneMask', () => {
-  it('should format phone numbers correctly when typing', async () => {
-  
+
+  it('should format phone numbers correctly when typing with selected contury code', async () => {
+    
+    // Test formatting for US
+    countrySelector.value = 'US';
+    
     input.value = '';
     PhoneMask.attach('#phone');
     
@@ -52,12 +68,36 @@ describe('PhoneMask', () => {
     expect(input.value).to.equal('012-345-6789');
   });
 
-  it('should format phone numbers correctly when pasting', async () => {
-   
-    input.value = '1234567890';
-    PhoneMask.attach('#phone');
+
+  it('should update format correctly with country code selected', async () => {
+
+    // Test formatting for US
+    countrySelector.value = 'US';
+    input.value = '1234567890'; // Set a US phone number
     input.dispatchEvent(new window.Event('input'));
 
-    expect(input.value).to.equal('123-456-7890');
+    expect(input.value).to.equal('123-456-7890'); // Check US formatted value
+
+    // Test formatting for UK
+    countrySelector.value = 'UK';
+    input.value = '123456789'; // Set a UK phone number
+    input.dispatchEvent(new window.Event('input'));
+
+    expect(input.value).to.equal('1234 567 89'); // Check UK formatted value
+
+    // Test formatting for FR
+    countrySelector.value = 'FR';
+    input.value = '123456789'; // Set a FR phone number
+    input.dispatchEvent(new window.Event('input'));
+
+    expect(input.value).to.equal('1 23 45 67 89'); // Check FR formatted value
+
+
+    // Test formatting for KR
+    countrySelector.value = 'KR';
+    input.value = '010-1234-6789'; // Set a KR phone number
+    input.dispatchEvent(new window.Event('input'));
+
+    expect(input.value).to.equal('010-1234-6789'); // Check KR formatted value
   });
 });


### PR DESCRIPTION
### This PR handles [Issue#1](https://github.com/ozkary/UISpark/issues/1)

The PhoneMask component now supports international phone formats for the following countries: United States (US), United Kingdom (UK), France (FR), and South Korea (KR).

### Key Features:
Dynamic Formatting: Automatically formats phone numbers based on the selected country code.
Future Scalability: The existing code structure is designed for easy expansion, allowing for the addition of more countries as needed.

### Future Enhancements:
To support more countries, simply add their respective formatting patterns and rules to the formats object in the code. This modular approach ensures that maintaining and extending the component is straightforward.

### Points to Note
Since I am not fully aware of use cases, I assumed that the user selects the coutrny code with dropdown box,
and only enters their own phone number.